### PR TITLE
Update 0.13.6

### DIFF
--- a/configurator/src/main.rs
+++ b/configurator/src/main.rs
@@ -141,6 +141,12 @@ struct RTLNodeSettings {
     theme_color: RTLNodeThemeColor,
     theme_mode: RTLNodeThemeMode,
     user_persona: RTLNodePersona,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    enable_offers: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    unannounced_channels: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    currency_unit: Option<String>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -273,6 +279,9 @@ fn to_rtl_default(
             fiat_conversion: false,
             channel_backup_path: Some(format!("/root/backup/node-{}", node_index).into()),
             ln_server_url: Some(format!("https://{}:{}", address, rest_port).into()),
+            enable_offers: None,
+            unannounced_channels: None,
+            currency_unit: None,
         },
     }
 }
@@ -291,6 +300,9 @@ fn to_rtl(
         def.settings.theme_color = prev.settings.theme_color;
         def.settings.theme_mode = prev.settings.theme_mode;
         def.settings.fiat_conversion = prev.settings.fiat_conversion;
+        def.settings.enable_offers = prev.settings.enable_offers;
+        def.settings.unannounced_channels = prev.settings.unannounced_channels;
+        def.settings.currency_unit = prev.settings.currency_unit;
     }
     def
 }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,9 +1,10 @@
 id: ride-the-lightning
 title: Ride the Lightning
-version: 0.13.4
+version: 0.13.5
 release-notes: |
-  * Update upstream to 0.13.4
+  * Update upstream to [v0.13.5](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.13.5)
   * Update CLN dependency requirement to accommodate up to v23.10
+  * Fix password updates and in-app config saves
 license: MIT
 wrapper-repo: https://github.com/Start9Labs/ride-the-lightning-wrapper
 upstream-repo: https://github.com/Ride-The-Lightning/RTL

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,8 @@
 id: ride-the-lightning
 title: Ride the Lightning
-version: 0.13.5
+version: 0.13.6
 release-notes: |
-  * Update upstream to [v0.13.5](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.13.5)
+  * Update upstream to [v0.13.6](https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.13.6)
   * Update CLN dependency requirement to accommodate up to v23.10
   * Fix password updates and in-app config saves
 license: MIT

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -85,5 +85,5 @@ export const migration: T.ExpectedExports.migration = compat.migrations
         ),
       },
     },
-    "0.13.4",
+    "0.13.5",
   );

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -85,5 +85,5 @@ export const migration: T.ExpectedExports.migration = compat.migrations
         ),
       },
     },
-    "0.13.5",
+    "0.13.6",
   );


### PR DESCRIPTION
Upstream update and bugfixes

- allow user to update password
- disallow output of keys with null values
- fix in-app config saves
- fix offers compatibility with CLN v22

Waiting for RTL 0.13.6 and cl-rest 0.10.1 release tags for offers fix