### PR TITLE
fix cln dependency config

### DIFF
--- a/scripts/procedures/dependencies.ts
+++ b/scripts/procedures/dependencies.ts
@@ -5,7 +5,7 @@ const { shape, boolean } = matches;
 const matchClnConfig = shape({
   advanced: shape({
     plugins: shape({
-      rest: boolean,
+      clnrest: boolean,
     })
   })
 });
@@ -16,8 +16,8 @@ export const dependencies: T.ExpectedExports.dependencies = {
     async check(effects, configInput) {
       effects.info("check c-lightning");
       const config = matchClnConfig.unsafeCast(configInput);
-      if (!config.advanced.plugins.rest) {
-        return { error: "C-Lightning-REST plugin must be enabled"};
+      if (!config.advanced.plugins.clnrest) {
+        return { error: "CLNRest plugin must be enabled"};
       }
       return { result: null };
     },
@@ -25,7 +25,7 @@ export const dependencies: T.ExpectedExports.dependencies = {
     async autoConfigure(effects, configInput) {
       effects.info("autoconfigure c-lightning");
       const config = matchClnConfig.unsafeCast(configInput);
-      config.advanced.plugins.rest = true;
+      config.advanced.plugins.clnrest = true;
       return { result: config };
     },
   },


### PR DESCRIPTION
Require and autoconfigure CLN to have CLNRest enabled rather that c-Lightning-REST