### PR TITLE
setNodes: fix remote macaroon round-trip

### DIFF
--- a/startos/actions/setNodes.ts
+++ b/startos/actions/setNodes.ts
@@ -5,6 +5,21 @@ import { RtlConfig } from '../fileModels/RTL-Config.json'
 import { clnMountpoint, hasInternal, lndMountpoint } from '../utils'
 const { InputSpec, Value, List } = sdk
 
+// Persistent package data volume. RTL's subcontainer bind-mounts it at /root
+// (see main.ts), so paths stored in RTL-Config.json use that form. The action
+// runtime (where this code executes) is a *different* filesystem context where
+// the same volume is reachable at /media/startos/volumes/main. Any disk
+// operation from inside this action must translate /root/... to the action-
+// runtime-visible path; otherwise writes land in an overlay filesystem that
+// RTL never sees, leaving the node entry in the config but no macaroon file
+// where RTL can read it.
+const VOLUME_ROOT_RTL = '/root'
+const VOLUME_ROOT_DISK = '/media/startos/volumes/main'
+const toDisk = (rtlPath: string): string =>
+  rtlPath.startsWith(`${VOLUME_ROOT_RTL}/`)
+    ? `${VOLUME_ROOT_DISK}${rtlPath.slice(VOLUME_ROOT_RTL.length)}`
+    : rtlPath
+
 export const remoteNodes = Value.list(
   List.obj(
     {
@@ -121,7 +136,7 @@ export const setNodes = sdk.Action.withInput(
               n.authentication.macaroonPath || n.authentication.runePath || ''
             const credFile =
               n.lnImplementation === 'LND' ? 'admin.macaroon' : 'access.macaroon'
-            const raw = await readFile(`${credDir}/${credFile}`)
+            const raw = await readFile(`${toDisk(credDir)}/${credFile}`)
             const macaroon = raw
               .toString('base64')
               .replace(/\+/g, '-')
@@ -145,7 +160,7 @@ export const setNodes = sdk.Action.withInput(
 
     if (input.internalNodes.includes('lnd')) {
       const channelBackupPath = `${internalBackupPath}LND`
-      await mkdir(channelBackupPath, { recursive: true })
+      await mkdir(toDisk(channelBackupPath), { recursive: true })
 
       nodes.push(
         await toRtlNode({
@@ -163,7 +178,7 @@ export const setNodes = sdk.Action.withInput(
 
     if (input.internalNodes.includes('cln')) {
       const channelBackupPath = `${internalBackupPath}CLN`
-      await mkdir(channelBackupPath, { recursive: true })
+      await mkdir(toDisk(channelBackupPath), { recursive: true })
 
       nodes.push(
         await toRtlNode({
@@ -189,15 +204,17 @@ export const setNodes = sdk.Action.withInput(
 
         // macaroon: decode base64url string from the form back to raw binary
         // bytes before persisting. Upstream RTL expects the on-disk file to be
-        // raw macaroon bytes; writing the ASCII base64url text would fail auth.
+        // raw macaroon bytes; writing the ASCII base64url text would fail
+        // auth. Write to the action-runtime-visible path so the bytes land in
+        // the persistent data volume that RTL's subcontainer sees at /root.
         const credentialPath = `/root/remote-macaroons/${hyphenatedName}`
-        await mkdir(credentialPath, { recursive: true })
+        await mkdir(toDisk(credentialPath), { recursive: true })
         const macaroonBytes = Buffer.from(
           macaroon.replace(/-/g, '+').replace(/_/g, '/'),
           'base64',
         )
         await writeFile(
-          `${credentialPath}/${
+          `${toDisk(credentialPath)}/${
             lnImplementation === 'LND' ? 'admin' : 'access'
           }.macaroon`,
           macaroonBytes,
@@ -205,7 +222,7 @@ export const setNodes = sdk.Action.withInput(
 
         // backup
         const channelBackupPath = `/root/backup/${hyphenatedName}`
-        await mkdir(channelBackupPath, { recursive: true })
+        await mkdir(toDisk(channelBackupPath), { recursive: true })
 
         const savedNode = config.nodes.find((n) => n.lnNode === lnNode)
 

--- a/startos/actions/setNodes.ts
+++ b/startos/actions/setNodes.ts
@@ -116,17 +116,23 @@ export const setNodes = sdk.Action.withInput(
               !n.settings.lnServerUrl.includes('lnd.startos') &&
               !n.settings.lnServerUrl.includes('c-lightning.startos'),
           )
-          .map(async (n) => ({
-            lnImplementation: n.lnImplementation,
-            lnNode: n.lnNode,
-            lnServerUrl: n.settings.lnServerUrl,
-            macaroon: await readFile(
-              n.authentication.macaroonPath || n.authentication.runePath || '',
-              {
-                encoding: 'base64',
-              },
-            ),
-          })),
+          .map(async (n) => {
+            const credDir =
+              n.authentication.macaroonPath || n.authentication.runePath || ''
+            const credFile =
+              n.lnImplementation === 'LND' ? 'admin.macaroon' : 'access.macaroon'
+            const raw = await readFile(`${credDir}/${credFile}`)
+            const macaroon = raw
+              .toString('base64')
+              .replace(/\+/g, '-')
+              .replace(/\//g, '_')
+            return {
+              lnImplementation: n.lnImplementation,
+              lnNode: n.lnNode,
+              lnServerUrl: n.settings.lnServerUrl,
+              macaroon,
+            }
+          }),
       ),
     }
   },
@@ -181,14 +187,20 @@ export const setNodes = sdk.Action.withInput(
         const { lnImplementation, lnNode, lnServerUrl, macaroon } = node
         const hyphenatedName = lnNode.replace(/\s+/g, '-')
 
-        // macaroon
+        // macaroon: decode base64url string from the form back to raw binary
+        // bytes before persisting. Upstream RTL expects the on-disk file to be
+        // raw macaroon bytes; writing the ASCII base64url text would fail auth.
         const credentialPath = `/root/remote-macaroons/${hyphenatedName}`
         await mkdir(credentialPath, { recursive: true })
+        const macaroonBytes = Buffer.from(
+          macaroon.replace(/-/g, '+').replace(/_/g, '/'),
+          'base64',
+        )
         await writeFile(
           `${credentialPath}/${
             lnImplementation === 'LND' ? 'admin' : 'access'
           }.macaroon`,
-          macaroon,
+          macaroonBytes,
         )
 
         // backup

--- a/startos/actions/setNodes.ts
+++ b/startos/actions/setNodes.ts
@@ -136,11 +136,9 @@ export const setNodes = sdk.Action.withInput(
               n.authentication.macaroonPath || n.authentication.runePath || ''
             const credFile =
               n.lnImplementation === 'LND' ? 'admin.macaroon' : 'access.macaroon'
-            const raw = await readFile(`${toDisk(credDir)}/${credFile}`)
-            const macaroon = raw
-              .toString('base64')
-              .replace(/\+/g, '-')
-              .replace(/\//g, '_')
+            const macaroon = (
+              await readFile(`${toDisk(credDir)}/${credFile}`)
+            ).toString('base64url')
             return {
               lnImplementation: n.lnImplementation,
               lnNode: n.lnNode,
@@ -209,15 +207,11 @@ export const setNodes = sdk.Action.withInput(
         // the persistent data volume that RTL's subcontainer sees at /root.
         const credentialPath = `/root/remote-macaroons/${hyphenatedName}`
         await mkdir(toDisk(credentialPath), { recursive: true })
-        const macaroonBytes = Buffer.from(
-          macaroon.replace(/-/g, '+').replace(/_/g, '/'),
-          'base64',
-        )
         await writeFile(
           `${toDisk(credentialPath)}/${
             lnImplementation === 'LND' ? 'admin' : 'access'
           }.macaroon`,
-          macaroonBytes,
+          Buffer.from(macaroon, 'base64url'),
         )
 
         // backup


### PR DESCRIPTION
## Summary

Three bugs in `startos/actions/setNodes.ts` prevent external LND/CLN nodes from being usable via the **Set Nodes** action. Together they make the form unreopenable after a first save, produce unusable macaroon files even on a "successful" save, and write those files to a location RTL cannot read.

## Bug 1 — directory vs file mismatch between execute and pre-fill

The execute path writes the macaroon to `${credentialPath}/admin.macaroon` (i.e. *inside* the credential directory) but stores `macaroonPath: credentialPath` — the directory itself — in `RTL-Config.json`.

The pre-fill function then does:

```ts
macaroon: await readFile(n.authentication.macaroonPath || n.authentication.runePath || '', { encoding: 'base64' })
```

— treating that directory path as a file — which fails with **EISDIR** on every subsequent open of the form.

If a prior save failed mid-flight (leaving `macaroonPath` set in the config but no file staged on disk), pre-fill instead errors with **ENOENT**, which blocks the form entirely and leaves the package stuck without a way to recover from the UI.

## Bug 2 — macaroon is never decoded before being written

Execute does:

```ts
await writeFile(`${credentialPath}/${lnImplementation === 'LND' ? 'admin' : 'access'}.macaroon`, macaroon)
```

where `macaroon` is the **Base64URL-encoded string** from the form. RTL expects on-disk macaroon files to be raw binary, so the resulting file is the ASCII Base64URL text rather than decoded bytes. Even a "successful" save yields a macaroon file that cannot authenticate against the remote node.

## Bug 3 — credentials written to the wrong filesystem context

The action runs in the package's action-runtime filesystem context, which is distinct from the RTL subcontainer where the upstream app runs. The subcontainer bind-mounts the `main` volume at `/root` (see `main.ts`), so paths stored in `RTL-Config.json` legitimately use the `/root/...` form — but the action's own `mkdir`/`writeFile` calls using the same `/root/...` path land in the action runtime's ephemeral overlay, not in the persistent data volume RTL reads from.

Result: saving a remote node produces a config entry pointing at `/root/remote-macaroons/<name>` but no macaroon file anywhere RTL can see, so every `/api/lnd/...` call errors with `ENOENT` when RTL tries to read the credential.

## Fix

- **Pre-fill** reads the correct `<credDir>/admin.macaroon` or `<credDir>/access.macaroon` path (matching what execute writes) and re-encodes the bytes as Base64URL for the form field.
- **Execute** decodes the Base64URL input back to raw bytes via `Buffer.from(s.replace(/-/g, '+').replace(/_/g, '/'), 'base64')` before `writeFile`.
- A `toDisk(rtlPath)` helper translates `/root/...` (RTL's view) → `/media/startos/volumes/main/...` (the action runtime's view of the same persistent volume). All `mkdir`, `writeFile`, and `readFile` operations in this action now go through the translated path; config entries continue to use the `/root/...` form so RTL finds the files at runtime.

## Verification

Built from this branch, sideloaded on a live StartOS 4.x box (Start9 Server One), added seven remote LND nodes running on separate StartOS boxes via the Set Nodes UI. Form reopens cleanly with each macaroon pre-filled (Base64URL), RTL authenticates against each remote LND and shows channel, peer, and forwarding data in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)