### PR TITLE
fix: write remote-node credentials with restrictive modes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,4 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
-    secrets:
-      DEV_KEY: ${{ secrets.DEV_KEY }}
+    # No DEV_KEY — a PR build doesn't publish, so it doesn't need the signing key.

--- a/startos/actions/setNodes.ts
+++ b/startos/actions/setNodes.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'fs/promises'
+import { chmod, mkdir, readFile, writeFile } from 'fs/promises'
 import { rtlConfig } from '../fileModels/RTL-Config.json'
 import { sdk } from '../sdk'
 import { RtlConfig } from '../fileModels/RTL-Config.json'
@@ -58,7 +58,11 @@ export const remoteNodes = Value.list(
           placeholder: 'Remote Node 1',
           patterns: [
             {
-              regex: '[A-Za-z0-9]+',
+              // Anchored, matching the SDK's own convention for supplied
+              // patterns. This name becomes a directory under
+              // remote-macaroons/ and backup/, so an unanchored pattern would
+              // accept a value carrying path separators anywhere but the start.
+              regex: '^[A-Za-z0-9]+$',
               description: 'Name can only contain A-Z, a-z, and 0-9',
             },
           ],
@@ -242,18 +246,30 @@ export const setNodes = sdk.Action.withInput(
         // raw macaroon bytes; writing the ASCII base64url text would fail
         // auth. Write to the action-runtime-visible path so the bytes land in
         // the persistent data volume that RTL's subcontainer sees at /root.
+        // An LND admin macaroon and a CLN rune are full-control credentials for
+        // the node, so neither the file nor the directory holding it is left at
+        // the default 0644/0755. The chmod is not redundant with the create
+        // mode: both only apply when the entry is created, so an install that
+        // already wrote these at the old modes would otherwise keep them.
         const credentialPath = `/root/remote-macaroons/${hyphenatedName}`
-        await mkdir(toDisk(credentialPath), { recursive: true })
-        await writeFile(
-          `${toDisk(credentialPath)}/${
-            lnImplementation === 'LND' ? 'admin' : 'access'
-          }.macaroon`,
-          Buffer.from(macaroon, 'base64url'),
-        )
+        const credentialDir = toDisk(credentialPath)
+        await mkdir(credentialDir, { recursive: true, mode: 0o700 })
+        await chmod(credentialDir, 0o700)
+        const credentialFile = `${credentialDir}/${
+          lnImplementation === 'LND' ? 'admin' : 'access'
+        }.macaroon`
+        await writeFile(credentialFile, Buffer.from(macaroon, 'base64url'), {
+          mode: 0o600,
+        })
+        await chmod(credentialFile, 0o600)
 
         // backup
+        // Static channel backups are equally sensitive — they identify channels
+        // and peers, and are what a recovery is driven from.
         const channelBackupPath = `/root/backup/${hyphenatedName}`
-        await mkdir(toDisk(channelBackupPath), { recursive: true })
+        const channelBackupDir = toDisk(channelBackupPath)
+        await mkdir(channelBackupDir, { recursive: true, mode: 0o700 })
+        await chmod(channelBackupDir, 0o700)
 
         const savedNode = config.nodes.find((n) => n.lnNode === lnNode)
 

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,33 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '0.15.10:0',
+  version: '0.15.10:1',
   releaseNotes: {
-    en_US: `Updated Ride The Lightning to 0.15.10.
+    en_US: `Credentials for remote nodes are now stored with restrictive permissions.
 
-A security-hygiene release. Login requests are validated more strictly — two-factor setups are the most affected — and credentials are no longer written to node logs or returned by the configuration API. Authentication settings are now fixed on the server so they cannot be changed through the settings API, and channel-backup downloads are confined to the selected node's backup directory. A node with many channels no longer fires one alias lookup per channel at once, and a race that could send a request with the wrong node's credentials is fixed. Upstream also cleared every known vulnerability in its production dependencies.
+When you add a remote node, the macaroon or rune you paste in — which grants full control of that node — was written with the filesystem's ordinary default permissions rather than being restricted to the service, as were the directory holding it and the channel-backup directory beside it. All three are now locked down. Saving a node again applies this to credentials that were stored previously, not only to new ones.
 
-Full release notes: https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.10`,
-    es_ES: `Se actualizó Ride The Lightning a 0.15.10.
+The node name is also checked more strictly. It was validated against any part of the name rather than the whole of it, so a name only partly made of letters and numbers could slip through; that name becomes a directory holding the credential, so it is now required to match in full.`,
+    es_ES: `Las credenciales de los nodos remotos ahora se guardan con permisos restrictivos.
 
-Una versión centrada en la higiene de seguridad. Las solicitudes de inicio de sesión se validan de forma más estricta —las configuraciones con doble factor son las más afectadas— y las credenciales ya no se escriben en los registros de los nodos ni las devuelve la API de configuración. Los ajustes de autenticación quedan fijados en el servidor, de modo que no pueden cambiarse mediante la API de ajustes, y las descargas de copias de seguridad de canales se limitan al directorio de copias del nodo seleccionado. Un nodo con muchos canales ya no lanza una búsqueda de alias por canal a la vez, y se corrigió una condición de carrera que podía enviar una solicitud con las credenciales del nodo equivocado. Además, upstream resolvió todas las vulnerabilidades conocidas en sus dependencias de producción.
+Al añadir un nodo remoto, el macaroon o rune que pega —que otorga control total de ese nodo— se escribía con los permisos predeterminados del sistema de archivos en lugar de quedar restringido al servicio, al igual que el directorio que lo contiene y el directorio de copias de seguridad de canales contiguo. Los tres quedan ahora protegidos. Volver a guardar un nodo aplica esto también a las credenciales guardadas anteriormente, no solo a las nuevas.
 
-Notas de la versión completas: https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.10`,
-    de_DE: `Ride The Lightning wurde auf 0.15.10 aktualisiert.
+El nombre del nodo también se comprueba de forma más estricta. Se validaba contra cualquier parte del nombre en lugar de contra el nombre completo, de modo que podía colarse un nombre formado solo en parte por letras y números; ese nombre se convierte en el directorio que guarda la credencial, así que ahora debe coincidir por completo.`,
+    de_DE: `Zugangsdaten für entfernte Knoten werden jetzt mit restriktiven Berechtigungen gespeichert.
 
-Eine Version zur Verbesserung der Sicherheitshygiene. Anmeldeanfragen werden strenger geprüft — Einrichtungen mit Zwei-Faktor-Authentifizierung sind am stärksten betroffen — und Zugangsdaten werden nicht mehr in Knoten-Logs geschrieben oder von der Konfigurations-API zurückgegeben. Authentifizierungseinstellungen sind jetzt serverseitig festgelegt und lassen sich nicht mehr über die Einstellungs-API ändern; Downloads von Kanal-Backups bleiben auf das Backup-Verzeichnis des ausgewählten Knotens beschränkt. Ein Knoten mit vielen Kanälen startet nicht mehr eine Alias-Abfrage pro Kanal gleichzeitig, und eine Race-Condition, die eine Anfrage mit den Zugangsdaten des falschen Knotens senden konnte, wurde behoben. Upstream hat außerdem alle bekannten Schwachstellen in seinen Produktionsabhängigkeiten beseitigt.
+Beim Hinzufügen eines entfernten Knotens wurde das eingefügte Macaroon bzw. die Rune — die volle Kontrolle über diesen Knoten gewährt — mit den üblichen Standardberechtigungen des Dateisystems geschrieben, statt auf den Dienst beschränkt zu sein; ebenso das zugehörige Verzeichnis und das daneben liegende Verzeichnis der Kanal-Backups. Alle drei sind nun abgesichert. Wird ein Knoten erneut gespeichert, gilt das auch für zuvor abgelegte Zugangsdaten, nicht nur für neue.
 
-Vollständige Versionshinweise: https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.10`,
-    pl_PL: `Zaktualizowano Ride The Lightning do 0.15.10.
+Auch der Knotenname wird strenger geprüft. Bisher wurde gegen einen beliebigen Teil des Namens geprüft statt gegen den ganzen, sodass ein nur teilweise aus Buchstaben und Ziffern bestehender Name durchrutschen konnte; aus diesem Namen wird das Verzeichnis der Zugangsdaten, daher muss er nun vollständig übereinstimmen.`,
+    pl_PL: `Poświadczenia zdalnych węzłów są teraz zapisywane z restrykcyjnymi uprawnieniami.
 
-Wydanie poświęcone higienie bezpieczeństwa. Żądania logowania są sprawdzane bardziej rygorystycznie — najbardziej dotyczy to konfiguracji z uwierzytelnianiem dwuskładnikowym — a dane uwierzytelniające nie trafiają już do logów węzłów ani nie są zwracane przez API konfiguracji. Ustawienia uwierzytelniania są teraz ustalone po stronie serwera, więc nie można ich zmienić przez API ustawień, a pobieranie kopii zapasowych kanałów ogranicza się do katalogu kopii wybranego węzła. Węzeł z wieloma kanałami nie wysyła już jednocześnie jednego zapytania o alias na kanał, a wyścig, który mógł wysłać żądanie z danymi uwierzytelniającymi niewłaściwego węzła, został naprawiony. Upstream usunął też wszystkie znane podatności w zależnościach produkcyjnych.
+Przy dodawaniu zdalnego węzła wklejany macaroon lub rune — dający pełną kontrolę nad tym węzłem — był zapisywany ze zwykłymi domyślnymi uprawnieniami systemu plików, zamiast być ograniczonym do samej usługi; tak samo katalog, który go przechowuje, i sąsiadujący katalog kopii zapasowych kanałów. Wszystkie trzy są teraz zabezpieczone. Ponowne zapisanie węzła stosuje to również do poświadczeń zapisanych wcześniej, nie tylko do nowych.
 
-Pełne informacje o wydaniu: https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.10`,
-    fr_FR: `Ride The Lightning a été mis à jour vers 0.15.10.
+Nazwa węzła jest też sprawdzana ściślej. Była weryfikowana względem dowolnej części nazwy, a nie całości, więc nazwa złożona tylko częściowo z liter i cyfr mogła się prześlizgnąć; z tej nazwy powstaje katalog przechowujący poświadczenie, dlatego teraz musi pasować w całości.`,
+    fr_FR: `Les identifiants des nœuds distants sont désormais enregistrés avec des permissions restrictives.
 
-Une version consacrée à l'hygiène de sécurité. Les demandes de connexion sont validées plus strictement — les configurations à deux facteurs sont les plus concernées — et les identifiants ne sont plus écrits dans les journaux des nœuds ni renvoyés par l'API de configuration. Les paramètres d'authentification sont désormais fixés côté serveur et ne peuvent donc plus être modifiés via l'API de paramètres, et les téléchargements de sauvegardes de canaux sont limités au répertoire de sauvegarde du nœud sélectionné. Un nœud comportant de nombreux canaux ne lance plus une recherche d'alias par canal en même temps, et une situation de compétition pouvant envoyer une requête avec les identifiants du mauvais nœud a été corrigée. En amont, toutes les vulnérabilités connues des dépendances de production ont également été éliminées.
+Lorsque vous ajoutez un nœud distant, le macaroon ou la rune que vous collez — qui donne le contrôle total de ce nœud — était écrit avec les permissions par défaut du système de fichiers au lieu d'être réservé au service, tout comme le répertoire qui le contient et le répertoire de sauvegardes de canaux voisin. Les trois sont maintenant verrouillés. Réenregistrer un nœud applique cela aux identifiants déjà stockés, et pas seulement aux nouveaux.
 
-Notes de version complètes : https://github.com/Ride-The-Lightning/RTL/releases/tag/v0.15.10`,
+Le nom du nœud est également vérifié plus strictement. Il était validé sur une partie quelconque du nom plutôt que sur son ensemble, si bien qu'un nom composé seulement en partie de lettres et de chiffres pouvait passer ; ce nom devient le répertoire qui contient l'identifiant, il doit donc désormais correspondre entièrement.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
From a community audit of this package at `ab1e076` (0.15.10:0). Code only — no version bump.

### Credential file modes

`setNodes` persists an LND **admin macaroon** or a CLN **rune** — full-control credentials for the remote node — passing no mode to either `writeFile` or `mkdir`, so they land at the default 0644/0755. Now 0600/0700, along with the channel-backup directory beside them.

The `chmod` is deliberate and not redundant with the create mode: a mode passed to `writeFile`/`mkdir` applies **only when the entry is created**, so an install that already wrote these would otherwise keep the loose modes forever. Verified RTL runs as root in `shahanafarooqui/rtl:v0.15.10` (`uid=0`, and its own `/root` is already `drwx------`), so nothing loses access.

### Node-name pattern anchored

`'[A-Za-z0-9]+'` → `'^[A-Za-z0-9]+$'`, matching the SDK's own convention (`ComposableRegex.matches()` anchors; every entry in `util/patterns.js` uses it). The name becomes a directory under `remote-macaroons/` and `backup/`, and unanchored the pattern accepts a value carrying path separators anywhere but the start.

Worth recording what the audit couldn't determine from this repo alone — **how far that pattern is actually enforced**:

- **UI:** enforced, and anchored either way. `form.service.ts` feeds `patterns[].regex` to Angular's `Validators.pattern`, which auto-anchors a **string** pattern (`Pattern.regex` is typed `string`, so it always is one).
- **SDK / backend:** not enforced at all. `Value.text`'s validator is `asRequiredParser(z.string(), a)` — `patterns`, `minLength` and `maxLength` are spec metadata the runtime never tests.
- **Another package:** cannot reach it. `effects.action.run` is gated on `ActionAccess`, which **defaults to `user`** when an action doesn't declare one — and no action here does. A service must go through `createTask`, which is a user-approved prompt.

So the only caller who can bypass the pattern is the box owner via the API/CLI, on their own node — self-harm, not a privilege boundary. That's why this is the anchor and the modes rather than in-code path confinement.

### `build.yml` no longer passes `DEV_KEY`

A PR build only compiles and packs, and `build.yml` already falls back to `start-cli init-key` when the secret is absent.

### The vendored-upstream findings

The 2026-08-11 round is six findings against RTL v0.15.10 itself (we ship `shahanafarooqui/rtl:v0.15.10`), so none are wrapper changes. One is worth flagging specifically:

> **FND-001 — Eclair `circularRebalance` route missing `isAuthenticated`** — rated **high**, and **not reachable as this package ships.** `setNodes` offers exactly two implementations, `LND` and `CLN`; Eclair is never a configurable backend here, so no Eclair node exists for that route to act on.

The other five are real upstream issues and good candidates for an upstream report — the `genSeed` one most of all, since it writes a freshly generated aezeed mnemonic into the logs as an INFO payload:

| Finding | Note |
|---|---|
| `genSeed` logs the aezeed mnemonic at INFO | worst of the five — a wallet seed in the log stream |
| Login rate limit keyed on `X-Forwarded-For` (`trust proxy` on) | attacker-controlled key defeats the 5-attempt lockout |
| UI password stored as unsalted SHA-256, which *is* the login credential | pass-the-hash |
| Session JWTs signed without expiry, never revoked | logout and password reset don't invalidate |
| `GET /api/conf/updateSelNode/...` unauthenticated, mutates process state | |